### PR TITLE
Moved database scripts under CDTADPQ.data and made recreate script

### DIFF
--- a/CDTADPQ/data/recreate.py
+++ b/CDTADPQ/data/recreate.py
@@ -1,0 +1,15 @@
+import psycopg2, os.path, glob
+
+def main(database_url):
+    '''
+    '''
+    pattern = os.path.join(os.path.dirname(__file__), 'scripts', '???-*.pgsql')
+    
+    with psycopg2.connect(database_url) as conn:
+        with conn.cursor() as db:
+            for filename in sorted(glob.glob(pattern)):
+                with open(filename) as file:
+                    db.execute(file.read())
+
+if __name__ == '__main__':
+    exit(main(os.environ['DATABASE_URL']))

--- a/CDTADPQ/data/scripts/000-create.pgsql
+++ b/CDTADPQ/data/scripts/000-create.pgsql
@@ -8,5 +8,3 @@ CREATE TABLE world
 );
 
 SELECT AddGeometryColumn('world', 'geom', 4326, 'POLYGON', 2);
-
-INSERT INTO world (geom) VALUES (ST_SetSRID(ST_MakeBox2D(ST_MakePoint(-180, -90), ST_MakePoint(180, 90)), 4326));

--- a/CDTADPQ/data/scripts/999-sample.pgsql
+++ b/CDTADPQ/data/scripts/999-sample.pgsql
@@ -1,0 +1,1 @@
+INSERT INTO world (geom) VALUES (ST_SetSRID(ST_MakeBox2D(ST_MakePoint(-180, -90), ST_MakePoint(180, 90)), 4326));

--- a/CDTADPQ/web/test_init.py
+++ b/CDTADPQ/web/test_init.py
@@ -1,16 +1,13 @@
-import unittest, os, psycopg2, json
+import unittest, os, json
 from .. import web
+from ..data import recreate
 
 class AppTests (unittest.TestCase):
 
     def setUp(self):
         '''
         '''
-        with open(os.path.join(os.path.dirname(__file__), '..', '..', 'app.pgsql')) as file:
-            with psycopg2.connect(os.environ['DATABASE_URL']) as conn:
-                with conn.cursor() as db:
-                    db.execute(file.read())
-
+        recreate.main(os.environ['DATABASE_URL'])
         self.client = web.app.test_client()
     
     def test_index(self):

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "vlg-cdtadpq",
   "scripts": {
-    "postdeploy": "cat app.pgsql | psql $DATABASE_URL"
+    "postdeploy": "python -m CDTADPQ.data.recreate"
   },
   "env": {
     "FLASK_SECRET_KEY": {


### PR DESCRIPTION
This greatly simplifies the amount of work we need to do in a `TestCase.setUp()` method.