### PR TITLE
Profile layout

### DIFF
--- a/CDTADPQ/web/__init__.py
+++ b/CDTADPQ/web/__init__.py
@@ -30,6 +30,10 @@ def get_about():
 def get_register():
     return flask.render_template('register.html')
 
+@app.route('/login', methods=['GET'])
+def get_login():
+    return flask.render_template('login.html')
+
 @app.route('/register', methods=['POST'])
 def post_register():
     with psycopg2.connect(os.environ['DATABASE_URL']) as conn:

--- a/CDTADPQ/web/templates/confirmation.html
+++ b/CDTADPQ/web/templates/confirmation.html
@@ -10,35 +10,6 @@
   <p>You can make changes to the alerts you'll receive here. By default, you're signed up to receive all alerts.</p>
   <!-- end confirmation only block -->
   
-  <fieldset class="usa-fieldset-inputs usa-sans">
-
-    <legend class="usa-sr-only">Alert options</legend>
-
-    <label for="input-type-text">Phone number</label>
-  	<input id="input-type-text" name="input-type-text" type="text" value="123-4567-342">
-
-  	<label for="input-type-text">Zip code</label>
-  	<input id="input-type-text" name="input-type-text" type="text" value="94103">
-
-    <ul class="usa-unstyled-list">
-      <li>
-        <input id="fire" type="checkbox" name="alert-type" value="truth" checked>
-        <label for="fire">Fire</label>
-      </li>
-      <li>
-        <input id="flood" type="checkbox" name="alert-type" value="truth" checked>
-        <label for="flood">Flood</label>
-      </li>
-      <li>
-        <input id="tsunami" type="checkbox" name="alert-type" value="truth" checked>
-        <label for="tsunami">Tsunami</label>
-      </li>
-      <li>
-        <input id="earthquake" type="checkbox" name="alert-type" value="truth" checked>
-        <label for="earthquake">Earthquake</label>
-      </li>
-    </ul>
-
-  </fieldset>
+ {% include 'includes/settings.html' %}
   
 {% endblock %}

--- a/CDTADPQ/web/templates/includes/settings.html
+++ b/CDTADPQ/web/templates/includes/settings.html
@@ -1,0 +1,30 @@
+ <fieldset class="usa-fieldset-inputs usa-sans">
+
+    <legend class="usa-sr-only">Alert options</legend>
+
+    <label for="input-type-text">Phone number</label>
+    <input id="input-type-text" name="input-type-text" type="text" value="123-4567-342">
+
+    <label for="input-type-text">Zip code</label>
+    <input id="input-type-text" name="input-type-text" type="text" value="94103">
+
+    <ul class="usa-unstyled-list">
+      <li>
+        <input id="fire" type="checkbox" name="alert-type" value="truth" checked>
+        <label for="fire">Fire</label>
+      </li>
+      <li>
+        <input id="flood" type="checkbox" name="alert-type" value="truth" checked>
+        <label for="flood">Flood</label>
+      </li>
+      <li>
+        <input id="tsunami" type="checkbox" name="alert-type" value="truth" checked>
+        <label for="tsunami">Tsunami</label>
+      </li>
+      <li>
+        <input id="earthquake" type="checkbox" name="alert-type" value="truth" checked>
+        <label for="earthquake">Earthquake</label>
+      </li>
+    </ul>
+
+  </fieldset>

--- a/CDTADPQ/web/templates/index.html
+++ b/CDTADPQ/web/templates/index.html
@@ -9,8 +9,10 @@
   {% include 'includes/map.html' %}
  
   <h2 id="section-heading-h2"></h2>
-  <p>If you'd like to receive notifications of emergency events happening in your local area.</p>
+  <p>If you'd like to receive notifications when there are changes, you can sign up for text message alerts.</p>
+ 
   <div class="button_wrapper">
-    <button>Sign up</button> <button>Log in</button>
+    <button>Sign up</button>
   </div>
+ 
 {% endblock %}

--- a/CDTADPQ/web/templates/layout.html
+++ b/CDTADPQ/web/templates/layout.html
@@ -26,8 +26,8 @@
         <ul class="usa-nav-primary usa-accordion">
           
           <li>
-            <a class="usa-nav-link" href="/register">
-              <span>Register</span>
+            <a class="usa-nav-link" href="/login">
+              <span>Login</span>
             </a>
           </li>
           <li>

--- a/CDTADPQ/web/templates/login.html
+++ b/CDTADPQ/web/templates/login.html
@@ -1,0 +1,20 @@
+{% extends "layout.html" %}
+
+{% block title %}California Emergency Alerts{% endblock %}
+
+
+{% block main_content %}
+  <h1>Login</h1>
+  
+  
+
+   <form id="sign-up" class="usa-form" action="{{ url_for('post_register') }}" method="post">
+   
+      <label for="phone-number" class="usa-input-required">Phone number</label>
+      <input id="phone-number" name="phone-number" type="tel" required="" aria-required="true">
+      <div class="button_wrapper">
+		<button>Send confirmation message</button>
+	
+  </form>
+  
+{% endblock %}

--- a/CDTADPQ/web/templates/profile.html
+++ b/CDTADPQ/web/templates/profile.html
@@ -1,0 +1,14 @@
+{% extends "layout.html" %}
+
+{% block title %}California Emergency Alerts{% endblock %}
+
+
+{% block main_content %}
+  
+  <h1>Your alert settings</h1>
+  
+
+  
+ {% include 'includes/settings.html' %}
+  
+{% endblock %}

--- a/CDTADPQ/web/test_init.py
+++ b/CDTADPQ/web/test_init.py
@@ -33,7 +33,7 @@ class AppTests (unittest.TestCase):
         self.assertEqual(got1.status_code, 200)
         
         soup1 = bs4.BeautifulSoup(got1.data, 'html.parser')
-        link1 = soup1.find(text='Register').find_parent('a')
+        link1 = soup1.find(text='Login').find_parent('a')
         
         got2 = self.client.get(link1['href'])
         self.assertEqual(got2.status_code, 200)


### PR DESCRIPTION
Pulled out the settings into their own included file, so it can be re-used in a couple places (like profile, confirmation).

Moved a couple things in the header, too - now it just says "Login", and conditionally it should say "Logout" instead when @migurski has added the necessary logic.  I also added a stub for the login page (basically the same as register), but it'll need to go to /profile instead of /confirmation after the user gets and enters their SMS code.

I also pulled out the login button from the landing page - it seemed a bit redundant. 