### PR TITLE
Store zipcodes for users

### DIFF
--- a/CDTADPQ/data/test_users.py
+++ b/CDTADPQ/data/test_users.py
@@ -32,18 +32,18 @@ class UsersTests (unittest.TestCase):
         '''
         db = unittest.mock.Mock()
         
-        db.fetchone.return_value = ('1234', '+15105551212')
+        db.fetchone.return_value = ('1234', '+15105551212', '94612')
         verified = users.verify_user_signup(db, '1234', 'xxx-yy-zzz')
         
         self.assertEqual(verified, '+15105551212')
-        self.assertEqual(db.execute.mock_calls[-2][1], ('SELECT pin_number, phone_number FROM unverified_signups WHERE signup_id = %s', ('xxx-yy-zzz',)))
-        self.assertEqual(db.execute.mock_calls[-1][1], ('INSERT INTO users (phone_number) VALUES (%s)', ('+15105551212',)))
+        self.assertEqual(db.execute.mock_calls[-2][1], ('SELECT pin_number, phone_number, zipcode\n                  FROM unverified_signups WHERE signup_id = %s', ('xxx-yy-zzz',)))
+        self.assertEqual(db.execute.mock_calls[-1][1], ('INSERT INTO users (phone_number, zip_codes) VALUES (%s, %s)', ('+15105551212', ['94612'])))
         
         db.fetchone.return_value = None
         verified = users.verify_user_signup(db, '1234', 'xxx-yy-zzz')
         
         self.assertFalse(verified)
-        self.assertEqual(db.execute.mock_calls[-1][1], ('SELECT pin_number, phone_number FROM unverified_signups WHERE signup_id = %s', ('xxx-yy-zzz',)))
+        self.assertEqual(db.execute.mock_calls[-1][1], ('SELECT pin_number, phone_number, zipcode\n                  FROM unverified_signups WHERE signup_id = %s', ('xxx-yy-zzz',)))
     
     def test_send_verification_code(self):
         '''

--- a/CDTADPQ/data/test_users.py
+++ b/CDTADPQ/data/test_users.py
@@ -7,21 +7,23 @@ class UsersTests (unittest.TestCase):
         '''
         '''
         db, account = unittest.mock.Mock(), unittest.mock.Mock()
-        to_number, signup_id, pin_number = '+1 (510) 555-1212', 'xxx-yy-zzz', 1234
+        to_number, signup_id = '+1 (510) 555-1212', 'xxx-yy-zzz'
+        zipcode, pin_number = '94612', 1234
         
         with unittest.mock.patch('CDTADPQ.data.users.send_verification_code') as send_verification_code, \
              unittest.mock.patch('random.randint') as randint, \
              unittest.mock.patch('uuid.uuid4') as uuid4:
             randint.return_value = pin_number
             uuid4.return_value = signup_id
-            output_id = users.add_unverified_signup(db, account, to_number)
+            output_id = users.add_unverified_signup(db, account, to_number, zipcode)
         
         self.assertEqual(output_id, signup_id)
         
         db.execute.assert_called_once_with(
             '''INSERT INTO unverified_signups
-                  (signup_id, phone_number, pin_number) VALUES (%s, %s, %s)''',
-               (signup_id, to_number, str(pin_number)))
+                  (signup_id, phone_number, pin_number, zipcode)
+                  VALUES (%s, %s, %s, %s)''',
+               (signup_id, to_number, str(pin_number), zipcode))
         
         send_verification_code.assert_called_once_with(account, to_number, str(pin_number))
     

--- a/CDTADPQ/data/test_users.py
+++ b/CDTADPQ/data/test_users.py
@@ -79,3 +79,22 @@ class UsersTests (unittest.TestCase):
                 users.send_verification_code(account, '+1212BADCODE', '1234')
 
         self.assertEqual(str(error.exception), "The 'To' number is not a valid phone number.")
+    
+    def test_get_user_info(self):
+        '''
+        '''
+        db = unittest.mock.Mock()
+        
+        db.fetchone.return_value = ('+1 (510) 555-1212', ['94612'])
+        user_info = users.get_user_info(db, '+1 (510) 555-1212')
+
+        self.assertEqual(user_info, db.fetchone.return_value)
+        self.assertEqual(db.execute.mock_calls[-1][1],
+                         ('SELECT phone_number, zip_codes FROM users WHERE phone_number = %s', ('+1 (510) 555-1212',)))
+        
+        db.fetchone.return_value = None
+        user_info = users.get_user_info(db, '+1 (510) 555-1212')
+
+        self.assertEqual(user_info, db.fetchone.return_value)
+        self.assertEqual(db.execute.mock_calls[-1][1],
+                         ('SELECT phone_number, zip_codes FROM users WHERE phone_number = %s', ('+1 (510) 555-1212',)))

--- a/CDTADPQ/data/test_users.py
+++ b/CDTADPQ/data/test_users.py
@@ -55,16 +55,17 @@ class UsersTests (unittest.TestCase):
             if request.headers['Authorization'] != 'Basic c2lkOnNlY3JldA==':
                 return httmock.response(401, b'Go away')
             
+            body = 'Your CA Emergency Alert PIN number is 1234.\n\nIf you did not ask for this, please ignore this message.'
             form = dict(urllib.parse.parse_qsl(request.body))
             
             if form['From'] != 'number':
                 return httmock.response(404, b'Not the right number')
 
-            if form == {'From': 'number', 'To': '+15105551212', 'Body': 'Yo 1234'}:
+            if form == {'From': 'number', 'To': '+15105551212', 'Body': body}:
                 body = '''{"sid": "...", "date_created": "Wed, 22 Feb 2017 02:32:26 +0000", "date_updated": "Wed, 22 Feb 2017 02:32:26 +0000", "date_sent": null, "account_sid": "...", "to": "+15105551212", "from": "+15105551212", "messaging_service_sid": null, "body": "Yo", "status": "queued", "num_segments": "1", "num_media": "0", "direction": "outbound-api", "api_version": "2010-04-01", "price": null, "price_unit": "USD", "error_code": null, "error_message": null, "uri": "/2010-04-01/Accounts/.../Messages/....json", "subresource_uris": {"media": "/2010-04-01/Accounts/.../Messages/.../Media.json"}}'''
                 return httmock.response(201, body.encode('utf8'), {'Content-Type': 'application/json'})
 
-            if form == {'From': 'number', 'To': '+1212BADCODE', 'Body': 'Yo 1234'}:
+            if form == {'From': 'number', 'To': '+1212BADCODE', 'Body': body}:
                 body = '''{"code": 21211, "message": "The 'To' number is not a valid phone number.", "more_info": "https://www.twilio.com/docs/errors/21211", "status": 400}'''
                 return httmock.response(400, body.encode('utf8'), {'Content-Type': 'application/json'})
 

--- a/CDTADPQ/data/test_users.py
+++ b/CDTADPQ/data/test_users.py
@@ -63,9 +63,8 @@ class UsersTests (unittest.TestCase):
         verified = users.verify_user_signup(db, '1234', 'xxx-yy-zzz')
         
         self.assertEqual(verified, '+15105551212')
-        self.assertEqual(db.execute.mock_calls[-3][1], ('SELECT pin_number, phone_number, zipcode\n                  FROM unverified_signups WHERE signup_id = %s', ('xxx-yy-zzz',)))
-        self.assertEqual(db.execute.mock_calls[-2][1], ('SELECT true FROM users WHERE phone_number = %s', ('+15105551212', )))
-        self.assertEqual(db.execute.mock_calls[-1][1], ('UPDATE users SET zip_codes = %s WHERE phone_number = %s', (['94612'], '+15105551212')))
+        self.assertEqual(db.execute.mock_calls[-2][1], ('SELECT pin_number, phone_number, zipcode\n                  FROM unverified_signups WHERE signup_id = %s', ('xxx-yy-zzz',)))
+        self.assertEqual(db.execute.mock_calls[-1][1], ('SELECT true FROM users WHERE phone_number = %s', ('+15105551212', )))
         
     def test_verify_user_signup_no_match(self):
         '''

--- a/CDTADPQ/data/users.py
+++ b/CDTADPQ/data/users.py
@@ -55,9 +55,16 @@ def verify_user_signup(db, given_pin_number, signup_id):
     
     if given_pin_number != expected_pin_number:
         return False
-
-    db.execute('INSERT INTO users (phone_number, zip_codes) VALUES (%s, %s)',
-               (phone_number, [zipcode]))
+    
+    db.execute('SELECT true FROM users WHERE phone_number = %s', (phone_number, ))
+    existing_user = db.fetchone()
+    
+    if existing_user is None:
+        db.execute('INSERT INTO users (phone_number, zip_codes) VALUES (%s, %s)',
+                   (phone_number, [zipcode]))
+    else:
+        db.execute('UPDATE users SET zip_codes = %s WHERE phone_number = %s',
+                   ([zipcode], phone_number))
 
     return phone_number
 

--- a/CDTADPQ/data/users.py
+++ b/CDTADPQ/data/users.py
@@ -28,7 +28,8 @@ def send_verification_code(account, to_number, code):
     '''
     '''
     url = uritemplate.expand(TwilioURL, dict(account=account.account))
-    data = dict(From=account.number, To=to_number, Body='Yo {}'.format(code))
+    body = 'Your CA Emergency Alert PIN number is {}.\n\nIf you did not ask for this, please ignore this message.'.format(code)
+    data = dict(From=account.number, To=to_number, Body=body)
     auth = account.sid, account.secret
     posted = requests.post(url, auth=auth, data=data)
     

--- a/CDTADPQ/data/users.py
+++ b/CDTADPQ/data/users.py
@@ -10,15 +10,16 @@ class TwilioAccount:
         self.account = account
         self.number = number
 
-def add_unverified_signup(db, account, to_number):
+def add_unverified_signup(db, account, to_number, zipcode):
     logging.info('add_unverified_signup: {}'.format(to_number))
     
     pin_number = '{:04d}'.format(random.randint(0, 9999))
     signup_id = str(uuid.uuid4())
     
     db.execute('''INSERT INTO unverified_signups
-                  (signup_id, phone_number, pin_number) VALUES (%s, %s, %s)''',
-               (signup_id, to_number, pin_number))
+                  (signup_id, phone_number, pin_number, zipcode)
+                  VALUES (%s, %s, %s, %s)''',
+               (signup_id, to_number, pin_number, zipcode))
     
     send_verification_code(account, to_number, pin_number)
     return signup_id

--- a/CDTADPQ/data/users.py
+++ b/CDTADPQ/data/users.py
@@ -43,19 +43,20 @@ def send_verification_code(account, to_number, code):
 def verify_user_signup(db, given_pin_number, signup_id):
     '''
     '''
-    db.execute('''SELECT pin_number, phone_number FROM unverified_signups WHERE signup_id = %s''',
+    db.execute('''SELECT pin_number, phone_number, zipcode
+                  FROM unverified_signups WHERE signup_id = %s''',
                (signup_id, ))
     
     try:
-        (expected_pin_number, phone_number) = db.fetchone()
+        (expected_pin_number, phone_number, zipcode) = db.fetchone()
     except TypeError:
         return False
     
     if given_pin_number != expected_pin_number:
         return False
 
-    db.execute('INSERT INTO users (phone_number) VALUES (%s)',
-               (phone_number, ))
+    db.execute('INSERT INTO users (phone_number, zip_codes) VALUES (%s, %s)',
+               (phone_number, [zipcode]))
 
     return phone_number
 

--- a/CDTADPQ/data/users.py
+++ b/CDTADPQ/data/users.py
@@ -58,13 +58,14 @@ def verify_user_signup(db, given_pin_number, signup_id):
     
     db.execute('SELECT true FROM users WHERE phone_number = %s', (phone_number, ))
     existing_user = db.fetchone()
+    zip_codes = [zipcode] if zipcode else []
     
     if existing_user is None:
         db.execute('INSERT INTO users (phone_number, zip_codes) VALUES (%s, %s)',
-                   (phone_number, [zipcode]))
+                   (phone_number, zip_codes))
     else:
-        db.execute('UPDATE users SET zip_codes = %s WHERE phone_number = %s',
-                   ([zipcode], phone_number))
+        # Login screen does not offer a zip code input field
+        pass
 
     return phone_number
 

--- a/CDTADPQ/data/users.py
+++ b/CDTADPQ/data/users.py
@@ -58,3 +58,16 @@ def verify_user_signup(db, given_pin_number, signup_id):
                (phone_number, ))
 
     return phone_number
+
+def get_user_info(db, phone_number):
+    '''
+    '''
+    db.execute('SELECT phone_number, zip_codes FROM users WHERE phone_number = %s',
+               (phone_number, ))
+    
+    try:
+        (phone_number, zip_codes) = db.fetchone()
+    except TypeError:
+        return None
+    
+    return phone_number, zip_codes

--- a/CDTADPQ/web/__init__.py
+++ b/CDTADPQ/web/__init__.py
@@ -113,7 +113,13 @@ def get_zipcode():
 @app.route('/confirmation')
 @user_is_logged_in
 def get_confirmation():
-    return flask.render_template('confirmation.html', **template_kwargs())
+    with psycopg2.connect(os.environ['DATABASE_URL']) as conn:
+        with conn.cursor() as db:
+            phone_number, zip_codes = users.get_user_info(db, flask.session['phone_number'])
+        
+    zip_code_str = ', '.join(zip_codes) if zip_codes else ''
+    return flask.render_template('confirmation.html', phone_number=phone_number,
+                                 zip_codes=zip_code_str, **template_kwargs())
 
 @app.route('/profile')
 @user_is_logged_in

--- a/CDTADPQ/web/__init__.py
+++ b/CDTADPQ/web/__init__.py
@@ -124,7 +124,13 @@ def get_confirmation():
 @app.route('/profile')
 @user_is_logged_in
 def get_profile():
-    return flask.render_template('profile.html', **template_kwargs())
+    with psycopg2.connect(os.environ['DATABASE_URL']) as conn:
+        with conn.cursor() as db:
+            phone_number, zip_codes = users.get_user_info(db, flask.session['phone_number'])
+        
+    zip_code_str = ', '.join(zip_codes) if zip_codes else ''
+    return flask.render_template('profile.html', phone_number=phone_number,
+                                 zip_codes=zip_code_str, **template_kwargs())
 
 @app.route('/admin')
 def get_admin():

--- a/CDTADPQ/web/__init__.py
+++ b/CDTADPQ/web/__init__.py
@@ -70,7 +70,8 @@ def post_register():
         with conn.cursor() as db:
             twilio_account = flask.current_app.config['twilio_account']
             to_number = flask.request.form['phone-number']
-            signup_id = users.add_unverified_signup(db, twilio_account, to_number)
+            zipcode = flask.request.form.get('zipcode', None)
+            signup_id = users.add_unverified_signup(db, twilio_account, to_number, zipcode)
             return flask.redirect(flask.url_for('get_registered', signup_id=signup_id), code=303)
 
 @app.route('/registered/<signup_id>')

--- a/CDTADPQ/web/templates/includes/settings.html
+++ b/CDTADPQ/web/templates/includes/settings.html
@@ -3,10 +3,10 @@
     <legend class="usa-sr-only">Alert options</legend>
 
     <label for="input-type-text">Phone number</label>
-    <input id="input-type-text" name="input-type-text" type="text" value="123-4567-342">
+    <input id="input-type-text" name="input-type-text" type="text" value="{{ phone_number }}">
 
     <label for="input-type-text">Zip code</label>
-    <input id="input-type-text" name="input-type-text" type="text" value="94103">
+    <input id="input-type-text" name="input-type-text" type="text" value="{{ zip_codes }}">
 
     <ul class="usa-unstyled-list">
       <li>

--- a/CDTADPQ/web/test_init.py
+++ b/CDTADPQ/web/test_init.py
@@ -98,6 +98,8 @@ class AppTests (unittest.TestCase):
         soup4 = bs4.BeautifulSoup(got4.data, 'html.parser')
         text4 = soup4.find(text='Your Profile')
         self.assertIsNotNone(text4)
+        self.assertIn(data2['phone-number'].encode('utf8'), got4.data)
+        self.assertIn(data2['zipcode'].encode('utf8'), got4.data)
 
         # Ensure we're on the confirmation page
 

--- a/CDTADPQ/web/test_init.py
+++ b/CDTADPQ/web/test_init.py
@@ -53,6 +53,7 @@ class AppTests (unittest.TestCase):
         data2 = {input['name']: None for input in form2.find_all('input')}
         self.assertIn('phone-number', data2)
         data2['phone-number'] = '+1 (510) 555-1212'
+        data2['zipcode'] = '94612'
 
         # Enter phone number to register
 


### PR DESCRIPTION
This change completes support for the zip code when new users sign up, and does not clobber the zip code when users return via the login screen.

Closes #18.