### PR TITLE
Start adding user email support

### DIFF
--- a/CDTADPQ/data/test_users.py
+++ b/CDTADPQ/data/test_users.py
@@ -155,16 +155,16 @@ class UsersTests (unittest.TestCase):
         '''
         db = unittest.mock.Mock()
         
-        db.fetchone.return_value = ('+1 (510) 555-1212', ['94612'])
+        db.fetchone.return_value = ('+1 (510) 555-1212', ['94612'], 'user@example.com')
         user_info = users.get_user_info(db, '+1 (510) 555-1212')
 
         self.assertEqual(user_info, db.fetchone.return_value)
         self.assertEqual(db.execute.mock_calls[-1][1],
-                         ('SELECT phone_number, zip_codes FROM users WHERE phone_number = %s', ('+1 (510) 555-1212',)))
+                         ('SELECT phone_number, zip_codes, email_address\n                  FROM users WHERE phone_number = %s', ('+1 (510) 555-1212',)))
         
         db.fetchone.return_value = None
         user_info = users.get_user_info(db, '+1 (510) 555-1212')
 
         self.assertEqual(user_info, db.fetchone.return_value)
         self.assertEqual(db.execute.mock_calls[-1][1],
-                         ('SELECT phone_number, zip_codes FROM users WHERE phone_number = %s', ('+1 (510) 555-1212',)))
+                         ('SELECT phone_number, zip_codes, email_address\n                  FROM users WHERE phone_number = %s', ('+1 (510) 555-1212',)))

--- a/CDTADPQ/data/users.py
+++ b/CDTADPQ/data/users.py
@@ -81,3 +81,9 @@ def get_user_info(db, phone_number):
         return None
     
     return phone_number, zip_codes
+
+def update_email_address(db, phone_number, email_address):
+    '''
+    '''
+    db.execute('UPDATE users SET email_address = %s WHERE phone_number = %s',
+               (email_address, phone_number))

--- a/CDTADPQ/data/users.py
+++ b/CDTADPQ/data/users.py
@@ -97,15 +97,16 @@ def verify_user_signup(db, given_pin_number, signup_id):
 def get_user_info(db, phone_number):
     '''
     '''
-    db.execute('SELECT phone_number, zip_codes FROM users WHERE phone_number = %s',
+    db.execute('''SELECT phone_number, zip_codes, email_address
+                  FROM users WHERE phone_number = %s''',
                (phone_number, ))
     
     try:
-        (phone_number, zip_codes) = db.fetchone()
+        (phone_number, zip_codes, email_address) = db.fetchone()
     except TypeError:
         return None
     
-    return phone_number, zip_codes
+    return phone_number, zip_codes, email_address
 
 def update_email_address(db, phone_number, email_address):
     '''

--- a/CDTADPQ/web/__init__.py
+++ b/CDTADPQ/web/__init__.py
@@ -1,4 +1,4 @@
-import flask, codecs, psycopg2, os, json, functools, sys
+import flask, codecs, psycopg2, os, json, functools, sys, itsdangerous
 from ..data import users, zipcodes
 
 def user_is_logged_in(untouched_route):
@@ -137,6 +137,26 @@ def get_profile():
 def post_profile():
     print('FORM', flask.request.form)
     return 'UNDER CONSTRUCTION'
+
+@app.route('/profile/email-address', methods=['POST'])
+@user_is_logged_in
+def post_email_address():
+    signer = itsdangerous.URLSafeSerializer(flask.current_app.secret_key)
+    address_encoded = signer.dumps(email_address)
+    redirect_url = flask.url_for('get_email_addressed', address_encoded=address_encoded)
+    return flask.redirect(redirect_url, code=303)
+
+@app.route('/profile/email-addressed/<address_encoded>', methods=['GET'])
+@user_is_logged_in
+def get_email_addressed(address_encoded):
+    signer = itsdangerous.URLSafeSerializer(flask.current_app.secret_key)
+    email_address = signer.loads(address_encoded)
+    print('POOP', email_address, 'from', address_encoded)
+    return 'UNDER CONSTRUCTION'
+    with psycopg2.connect(os.environ['DATABASE_URL']) as conn:
+        with conn.cursor() as db:
+            phone_number = flask.session['phone_number']
+            users.update_email_address(db, phone_number, email_address)
 
 @app.route('/admin')
 def get_admin():

--- a/CDTADPQ/web/__init__.py
+++ b/CDTADPQ/web/__init__.py
@@ -121,7 +121,7 @@ def get_confirmation():
     return flask.render_template('confirmation.html', phone_number=phone_number,
                                  zip_codes=zip_code_str, **template_kwargs())
 
-@app.route('/profile')
+@app.route('/profile', methods=['GET'])
 @user_is_logged_in
 def get_profile():
     with psycopg2.connect(os.environ['DATABASE_URL']) as conn:
@@ -131,6 +131,12 @@ def get_profile():
     zip_code_str = ', '.join(zip_codes) if zip_codes else ''
     return flask.render_template('profile.html', phone_number=phone_number,
                                  zip_codes=zip_code_str, **template_kwargs())
+
+@app.route('/profile', methods=['POST'])
+@user_is_logged_in
+def post_profile():
+    print('FORM', flask.request.form)
+    return 'UNDER CONSTRUCTION'
 
 @app.route('/admin')
 def get_admin():

--- a/CDTADPQ/web/templates/email-registered.html
+++ b/CDTADPQ/web/templates/email-registered.html
@@ -1,0 +1,38 @@
+{% extends "layout.html" %}
+
+{% block title %}Sign Up{% endblock %}
+
+{% block sidenav %}
+{% endblock %}
+
+{% block main_content %}
+   <form id="register" class="usa-form" action="{{ url_for('post_email_confirm') }}" method="post">
+    <fieldset>
+      <legend>PIN Number</legend>
+
+      {% if error_wrong_pin_number %}
+         <div class="usa-alert usa-alert-error" role="alert">
+           <div class="usa-alert-body">
+             <h3 class="usa-alert-heading">Wrong PIN</h3>
+             <p class="usa-alert-text">You entered a wrong PIN number. Try again.</p>
+           </div>
+         </div>
+      {% endif %}
+      
+      <p>In a few minutes, you should receive a message to the email address you gave us.</p>
+      
+      <p>Enter the number here:</p>
+
+      <label for="pin-number" class="usa-input-required">PIN number</label>
+      <input id="pin-number" name="pin-number" type="text" required="" aria-required="true">
+      <input id="email-address" name="email-address" type="hidden" value="{{email_address}}">
+
+      <div class="button_wrapper">
+		<button>Submit</button>
+		</div>
+
+      <p>If you’ve waited more than 5 minutes, <a href="{{ url_for('get_profile') }}">go back and try again</a>.</p>
+
+    </fieldset>
+  </form>
+{% endblock %}

--- a/CDTADPQ/web/templates/includes/settings.html
+++ b/CDTADPQ/web/templates/includes/settings.html
@@ -9,9 +9,6 @@
     <label for="zip-codes">Zip code</label>
     <input id="zip-codes" name="zip-codes" type="text" value="{{ zip_codes }}">
 
-    <label for="email-address">Email address (optional)</label>
-    <input id="email-address" name="email-address" type="email" value="{{ email_address }}">
-
     <ul class="usa-unstyled-list">
       <li>
         <input id="fire" type="checkbox" name="fire" value="truth" checked>
@@ -30,7 +27,20 @@
         <label for="earthquake">Earthquake</label>
       </li>
     </ul>
-    
+
+  </fieldset>
+</form>
+
+<h2>Email alerts</h2>
+
+<form id="email-settings" class="usa-form" action="{{ url_for('post_email_address') }}" method="post">
+ <fieldset class="usa-fieldset-inputs usa-sans">
+
+    <legend class="usa-sr-only">Email address (optional)</legend>
+
+    <label for="email-address">Email address (optional)</label>
+    <input id="email-address" name="email-address" type="email" value="{{ email_address }}">
+
     <input type="submit">
 
   </fieldset>

--- a/CDTADPQ/web/templates/includes/settings.html
+++ b/CDTADPQ/web/templates/includes/settings.html
@@ -1,30 +1,37 @@
+<form id="profile-settings" class="usa-form" action="{{ url_for('post_profile') }}" method="post">
  <fieldset class="usa-fieldset-inputs usa-sans">
 
     <legend class="usa-sr-only">Alert options</legend>
 
-    <label for="input-type-text">Phone number</label>
-    <input id="input-type-text" name="input-type-text" type="text" value="{{ phone_number }}">
+    <label for="phone-number">Phone number</label>
+    <input id="phone-number" name="phone-number" type="text" value="{{ phone_number }}">
 
-    <label for="input-type-text">Zip code</label>
-    <input id="input-type-text" name="input-type-text" type="text" value="{{ zip_codes }}">
+    <label for="zip-codes">Zip code</label>
+    <input id="zip-codes" name="zip-codes" type="text" value="{{ zip_codes }}">
+
+    <label for="email-address">Email address (optional)</label>
+    <input id="email-address" name="email-address" type="email" value="{{ email_address }}">
 
     <ul class="usa-unstyled-list">
       <li>
-        <input id="fire" type="checkbox" name="alert-type" value="truth" checked>
+        <input id="fire" type="checkbox" name="fire" value="truth" checked>
         <label for="fire">Fire</label>
       </li>
       <li>
-        <input id="flood" type="checkbox" name="alert-type" value="truth" checked>
+        <input id="flood" type="checkbox" name="flood" value="truth" checked>
         <label for="flood">Flood</label>
       </li>
       <li>
-        <input id="tsunami" type="checkbox" name="alert-type" value="truth" checked>
+        <input id="tsunami" type="checkbox" name="tsunami" value="truth" checked>
         <label for="tsunami">Tsunami</label>
       </li>
       <li>
-        <input id="earthquake" type="checkbox" name="alert-type" value="truth" checked>
+        <input id="earthquake" type="checkbox" name="earthquake" value="truth" checked>
         <label for="earthquake">Earthquake</label>
       </li>
     </ul>
+    
+    <input type="submit">
 
   </fieldset>
+</form>

--- a/app.json
+++ b/app.json
@@ -23,7 +23,8 @@
   "formation": {
   },
   "addons": [
-    "heroku-postgresql"
+    "heroku-postgresql",
+    "mailgun:starter"
   ],
   "buildpacks": [
 

--- a/app.json
+++ b/app.json
@@ -18,13 +18,18 @@
     },
     "TWILIO_SECRET": {
       "value": "ZYJZpNqQOea84FEunVZY9NBX3FnldNSX"
+    },
+    "MAILGUN_API_KEY": {
+      "required": true
+    },
+    "MAILGUN_DOMAIN": {
+      "required": true
     }
   },
   "formation": {
   },
   "addons": [
-    "heroku-postgresql",
-    "mailgun:starter"
+    "heroku-postgresql"
   ],
   "buildpacks": [
 


### PR DESCRIPTION
Adds an email address to the profile form, and sends emails to one of our five pre-selected addresses when an address is added.

- [x] Add configuration for email sending
- [x] Add confirmation emails when user changes their address

Not yet:

- Send alert emails (SMS ones don't exist at all yet)
- PIN numbers other than "1234"

Part of #59.