### PR TITLE
Update user location from profile page

### DIFF
--- a/CDTADPQ/data/test_users.py
+++ b/CDTADPQ/data/test_users.py
@@ -168,3 +168,23 @@ class UsersTests (unittest.TestCase):
         self.assertEqual(user_info, db.fetchone.return_value)
         self.assertEqual(db.execute.mock_calls[-1][1],
                          ('SELECT phone_number, zip_codes, email_address\n                  FROM users WHERE phone_number = %s', ('+1 (510) 555-1212',)))
+    
+    def test_update_user_profile(self):
+        '''
+        '''
+        db = unittest.mock.Mock()
+
+        user_info = users.update_user_profile(db, '+1 (510) 555-1212', '94612')
+
+        self.assertEqual(db.execute.mock_calls[-1][1],
+                         ('UPDATE users SET zip_codes = %s\n                  WHERE phone_number = %s', (['94612'], '+1 (510) 555-1212')))
+
+        user_info = users.update_user_profile(db, '+1 (510) 555-1212', '94612, 94608')
+
+        self.assertEqual(db.execute.mock_calls[-1][1],
+                         ('UPDATE users SET zip_codes = %s\n                  WHERE phone_number = %s', (['94612', '94608'], '+1 (510) 555-1212')))
+
+        user_info = users.update_user_profile(db, '+1 (510) 555-1212', '94XXX')
+
+        self.assertEqual(db.execute.mock_calls[-1][1],
+                         ('UPDATE users SET zip_codes = %s\n                  WHERE phone_number = %s', ([], '+1 (510) 555-1212')))

--- a/CDTADPQ/data/users.py
+++ b/CDTADPQ/data/users.py
@@ -1,4 +1,4 @@
-import requests, logging, uritemplate, random, uuid
+import requests, logging, uritemplate, random, uuid, re
 
 TwilioURL = 'https://api.twilio.com/2010-04-01/Accounts/{account}/Messages.json'
 MailgunURL = 'https://api.mailgun.net/v2/{domain}/messages'
@@ -107,6 +107,15 @@ def get_user_info(db, phone_number):
         return None
     
     return phone_number, zip_codes, email_address
+
+def update_user_profile(db, phone_number, zip_codes_str):
+    '''
+    '''
+    zip_codes = re.findall(r'\b(\d{5})\b', zip_codes_str)
+    
+    db.execute('''UPDATE users SET zip_codes = %s
+                  WHERE phone_number = %s''',
+               (zip_codes, phone_number))
 
 def update_email_address(db, phone_number, email_address):
     '''

--- a/CDTADPQ/web/__init__.py
+++ b/CDTADPQ/web/__init__.py
@@ -168,7 +168,13 @@ def get_profile():
 @user_is_logged_in
 def post_profile():
     print('FORM', flask.request.form)
-    return 'UNDER CONSTRUCTION'
+    with psycopg2.connect(os.environ['DATABASE_URL']) as conn:
+        with conn.cursor() as db:
+            phone_number = flask.session['phone_number']
+            zip_codes_str = flask.request.form.get('zip-codes', '')
+            users.update_user_profile(db, phone_number, zip_codes_str)
+    redirect_url = flask.url_for('get_profile')
+    return flask.redirect(redirect_url, code=303)
 
 @app.route('/profile/email-address', methods=['POST'])
 @user_is_logged_in

--- a/CDTADPQ/web/__init__.py
+++ b/CDTADPQ/web/__init__.py
@@ -167,7 +167,6 @@ def get_profile():
 @app.route('/profile', methods=['POST'])
 @user_is_logged_in
 def post_profile():
-    print('FORM', flask.request.form)
     with psycopg2.connect(os.environ['DATABASE_URL']) as conn:
         with conn.cursor() as db:
             phone_number = flask.session['phone_number']

--- a/CDTADPQ/web/static/settings-geolocation.js
+++ b/CDTADPQ/web/static/settings-geolocation.js
@@ -1,0 +1,49 @@
+function zip_code_list(original_zipcodes_str, new_zipcode)
+{
+    var output_zipcodes = [],
+        input_zipcodes = original_zipcodes_str.split(',');
+    
+    for (var i in input_zipcodes)
+    {
+        output_zipcodes.push(input_zipcodes[i].trim());
+    }
+    
+    if(output_zipcodes.indexOf(new_zipcode) == -1)
+    {
+        output_zipcodes.push(new_zipcode);
+    }
+    
+    return output_zipcodes.join(', ');
+}
+
+function on_geolocation(position, original_zipcodes_str, zipcode_url)
+{
+    var input = document.getElementById('zip-codes'),
+        lat = position.coords.latitude,
+        lon = position.coords.longitude;
+
+    input.value = '';
+    input.placeholder = 'Finding zip code...';
+
+    var xhr = new XMLHttpRequest(),
+        url = zipcode_url + "?lat=" + encodeURIComponent(lat) + "&lon=" + encodeURIComponent(lon);
+
+    xhr.onreadystatechange = function()
+    {
+        var DONE = this.DONE || 4;
+        if (this.readyState === DONE){
+            var response = JSON.parse(this.responseText);
+
+            if('zipcode' in response) {
+                input.value = zip_code_list(original_zipcodes_str, response['zipcode']);
+                input.placeholder = '';
+            } else {
+                input.value = '';
+                input.placeholder = '';
+            }
+        }
+    }
+
+    xhr.open('GET', url, true);
+    xhr.send(null);
+}

--- a/CDTADPQ/web/templates/confirmation.html
+++ b/CDTADPQ/web/templates/confirmation.html
@@ -2,6 +2,9 @@
 
 {% block title %}California Emergency Alerts{% endblock %}
 
+{% block head_elements %}
+<script src="{{ url_for('static', filename='settings-geolocation.js') }}"></script>
+{% endblock %}
 
 {% block main_content %}
   <!-- This block would only show for a first-time confirm, after that, this is the profile editing screen -->

--- a/CDTADPQ/web/templates/includes/settings.html
+++ b/CDTADPQ/web/templates/includes/settings.html
@@ -8,7 +8,7 @@
 
     <label for="zip-codes">Zip code</label>
     <input id="zip-codes" name="zip-codes" type="text" value="{{ zip_codes }}">
-    <button id="zip-codes-update" onclick="return geolocate_me()" class="usa-button-disabled" disabled>Locate Me</button>
+    <button type="button" id="zip-codes-update" onclick="return geolocate_me()" class="usa-button-disabled" disabled>Locate Me</button>
 
     <script>
         function geolocate_me()
@@ -49,6 +49,8 @@
       </li>
     </ul>
 
+    <input type="submit" value="Update Profile">
+
   </fieldset>
 </form>
 
@@ -62,7 +64,7 @@
     <label for="email-address">Email address (optional)</label>
     <input id="email-address" name="email-address" type="email" value="{{ email_address }}">
 
-    <input type="submit">
+    <input type="submit" value="Update Email">
 
   </fieldset>
 </form>

--- a/CDTADPQ/web/templates/includes/settings.html
+++ b/CDTADPQ/web/templates/includes/settings.html
@@ -8,6 +8,27 @@
 
     <label for="zip-codes">Zip code</label>
     <input id="zip-codes" name="zip-codes" type="text" value="{{ zip_codes }}">
+    <button id="zip-codes-update" onclick="return geolocate_me()" class="usa-button-disabled" disabled>Locate Me</button>
+
+    <script>
+        function geolocate_me()
+        {
+            document.getElementById('zip-codes').value = '';
+            document.getElementById('zip-codes').placeholder = 'Locating you...';
+            // navigator.geolocation.getCurrentPosition(on_geolocation);
+            on_geolocation({coords: {latitude: 37.8043, longitude: -122.2712}},
+                           "{{ zip_codes }}", "{{ url_for('get_zipcode') }}");
+            return false;
+        }
+    
+        if('geolocation' in navigator)
+        {
+            var button = document.getElementById('zip-codes-update');
+            
+            button.className = 'usa-button-active';
+            button.disabled = false;
+        }
+    </script>
 
     <ul class="usa-unstyled-list">
       <li>

--- a/CDTADPQ/web/templates/includes/settings.html
+++ b/CDTADPQ/web/templates/includes/settings.html
@@ -15,9 +15,9 @@
         {
             document.getElementById('zip-codes').value = '';
             document.getElementById('zip-codes').placeholder = 'Locating you...';
-            // navigator.geolocation.getCurrentPosition(on_geolocation);
-            on_geolocation({coords: {latitude: 37.8043, longitude: -122.2712}},
-                           "{{ zip_codes }}", "{{ url_for('get_zipcode') }}");
+            navigator.geolocation.getCurrentPosition(function(pos) {
+                on_geolocation(pos, "{{ zip_codes }}", "{{ url_for('get_zipcode') }}");
+                });
             return false;
         }
     

--- a/CDTADPQ/web/templates/profile.html
+++ b/CDTADPQ/web/templates/profile.html
@@ -2,6 +2,9 @@
 
 {% block title %}California Emergency Alerts{% endblock %}
 
+{% block head_elements %}
+<script src="{{ url_for('static', filename='settings-geolocation.js') }}"></script>
+{% endblock %}
 
 {% block main_content %}
   

--- a/CDTADPQ/web/test_init.py
+++ b/CDTADPQ/web/test_init.py
@@ -186,9 +186,25 @@ class AppTests (unittest.TestCase):
         self.assertIsNotNone(header_text4)
         self.assertIn('profile', posted2.headers.get('Location'))
 
+        # Update the user's profile.
+        
+        form5 = soup4.find('form', id='profile-settings')
+        data5 = {input['name']: input.get('value') for input
+                 in form5.find_all('input') if input.get('name')}
+        
+        data5['zip-codes'] = '94612, 94608'
+        posted4 = self.client.open(method=form5['method'], path=form5['action'], data=data5)
+        self.assertEqual(posted4.status_code, 303)
+
+        got7 = self.client.get(posted4.headers.get('Location'))
+        self.assertEqual(got7.status_code, 200)
+        
+        html7 = got7.data.decode('utf8')
+        self.assertIn('94612, 94608', html7)
+
         form4 = soup4.find('form', id='log-out')
         data4 = {input['name']: input.get('value') for input in form4.find_all('input')}
-
+        
         # Log out using the form
 
         posted3 = self.client.open(method=form4['method'], path=form4['action'], data=data4)


### PR DESCRIPTION
There is now a "locate me" button next to the user’s zip code on the profile page. Clicking it will add the current geolocated zip code to the list. The user can also type one in.

- [x] Fix geolocation check as soon as Heroku gives back an HTTPS URL to test with.

Closes #52.