### PR TITLE
Notify users of fires

### DIFF
--- a/CDTADPQ/data/notify.py
+++ b/CDTADPQ/data/notify.py
@@ -53,7 +53,6 @@ def get_users_to_notify(db, fire_point):
                   ON zip_codes.zip_code = ANY (users.zip_codes)''',
                (geography_wkt, radius_meters))
 
-
     user_rows = db.fetchall()
     return user_rows
 

--- a/CDTADPQ/data/test_notify.py
+++ b/CDTADPQ/data/test_notify.py
@@ -32,28 +32,20 @@ class NotifyTests (unittest.TestCase):
     def test_main(self):
         '''
         '''
-        with unittest.mock.patch('CDTADPQ.data.notify.get_all_wild_fires') as get_all_wild_fires, \
+        with unittest.mock.patch('CDTADPQ.data.wildfires.get_current_fires') as get_current_fires, \
              unittest.mock.patch('CDTADPQ.data.notify.get_users_to_notify') as get_users_to_notify, \
              unittest.mock.patch('CDTADPQ.data.notify.send_notification') as send_notification:
-            get_all_wild_fires.return_value = [wildfires.FirePoint({"type": "Point", "coordinates": [-122, 37]}, '123', 'fire', 'True', 'now', 'people', 15)]
+            get_current_fires.return_value = [wildfires.FirePoint({"type": "Point", "coordinates": [-122, 37]}, '123', 'fire', 'True', 'now', 'people', 15)]
             get_users_to_notify.return_value = [{'phone_number': '+15105551212'}]
             notify.main()
-        self.assertEqual(len(get_all_wild_fires.mock_calls), 1)
+        self.assertEqual(len(get_current_fires.mock_calls), 1)
         self.assertEqual(len(get_users_to_notify.mock_calls), 1)
         self.assertEqual(len(send_notification.mock_calls), 1)
-
-    def test_get_all_wild_fires(self):
-        '''
-        '''
-        with psycopg2.connect(self.database_url) as conn:
-            with conn.cursor(cursor_factory = psycopg2.extras.DictCursor) as db:
-                fires = notify.get_all_wild_fires(db)
-                self.assertEqual(1, len(fires))
 
     def test_get_users_to_notify(self):
         with psycopg2.connect(self.database_url) as conn:
             with conn.cursor(cursor_factory = psycopg2.extras.DictCursor) as db:
-                (fire, ) = notify.get_all_wild_fires(db)
+                (fire, ) = wildfires.get_current_fires(db)
 
                 # Look for users within a half-mile of the fire
                 os.environ['RADIUS_MILES'] = '0.5'

--- a/CDTADPQ/data/test_wildfires.py
+++ b/CDTADPQ/data/test_wildfires.py
@@ -5,7 +5,6 @@ import psycopg2
 from . import recreate
 from . import wildfires
 
-
 class WildfireTests (unittest.TestCase):
     def setUp(self):
         '''
@@ -44,3 +43,22 @@ class WildfireTests (unittest.TestCase):
                 wildfires.store_fire_point(db, fire)
                 db.execute('SELECT * FROM fire_points WHERE usgs_id = %s', ('2017-OKNEU-170102',))
                 self.assertEqual(db.rowcount, 1)
+
+    def test_get_current_fires(self):
+        '''
+        '''
+        db = unittest.mock.Mock()
+        db.fetchall.return_value = []
+
+        fires0 = wildfires.get_current_fires(db)
+        self.assertEqual(db.execute.mock_calls[-1][1], ('SELECT ST_AsGeoJSON(location) as coordinates_json, * FROM fire_points', ))
+        self.assertEqual(len(fires0), 0)
+
+        db.fetchall.return_value = [
+            dict(coordinates_json='{"type": "Point", "coordinates": [-122, 37]}', usgs_id='FIRE', name='Fire',
+                 contained=0, discovered=None, cause='Bambi', acres=9999)
+            ]
+
+        fires1 = wildfires.get_current_fires(db)
+        self.assertEqual(db.execute.mock_calls[-1][1], ('SELECT ST_AsGeoJSON(location) as coordinates_json, * FROM fire_points', ))
+        self.assertEqual(len(fires1), 1)

--- a/CDTADPQ/data/test_wildfires.py
+++ b/CDTADPQ/data/test_wildfires.py
@@ -44,6 +44,19 @@ class WildfireTests (unittest.TestCase):
                 db.execute('SELECT * FROM fire_points WHERE usgs_id = %s', ('2017-OKNEU-170102',))
                 self.assertEqual(db.rowcount, 1)
 
+    def test_get_one_fire(self):
+        '''
+        '''
+        db = unittest.mock.Mock()
+
+        db.fetchone.return_value = dict(
+            coordinates_json='{"type": "Point", "coordinates": [-122, 37]}', usgs_id='FIRE', name='Fire',
+            contained=0, discovered=None, cause='Bambi', acres=9999
+            )
+
+        fire = wildfires.get_one_fire(db, 9999)
+        self.assertEqual(db.execute.mock_calls[-1][1], ('SELECT ST_AsGeoJSON(location) as coordinates_json, *\n                  FROM fire_points WHERE usgs_id = %s', (9999, )))
+
     def test_get_current_fires(self):
         '''
         '''

--- a/CDTADPQ/data/wildfires.py
+++ b/CDTADPQ/data/wildfires.py
@@ -17,6 +17,10 @@ class FirePoint:
         self.discovered = discovered
         self.cause = cause
         self.acres = acres
+    
+    def __str__(self):
+        x, y = self.location['coordinates']
+        return '{name} fire near {lat:.2f}, {lon:.2f}'.format(lon=x, lat=y, **self.__dict__)
 
 def store_fire_point(db, fire_point):
     ''' Add fire point to the db if the fire point does not already exist in the db

--- a/CDTADPQ/web/__init__.py
+++ b/CDTADPQ/web/__init__.py
@@ -242,7 +242,7 @@ def post_send_alert():
                 for user in notify.get_users_to_notify(db, emergency):
                     print('notify.send_notification:', user['phone_number'], emergency)
                     notify.send_notification(twilio_account, user['phone_number'], emergency)
-    return 'UNDER CONSTRUCTION'
+    return flask.redirect(flask.url_for('get_sent_alert'), code=303)
 
 @app.route('/admin/sent')
 @user_is_an_admin

--- a/CDTADPQ/web/__init__.py
+++ b/CDTADPQ/web/__init__.py
@@ -211,6 +211,9 @@ def post_email_confirm():
 @app.route('/admin/')
 @user_is_an_admin
 def get_admin():
+    with psycopg2.connect(os.environ['DATABASE_URL']) as conn:
+        with conn.cursor() as db:
+            pass
     return flask.render_template('admin.html', **template_kwargs())
 
 @app.route('/admin/send-alert')

--- a/CDTADPQ/web/__init__.py
+++ b/CDTADPQ/web/__init__.py
@@ -218,10 +218,15 @@ def get_admin():
     return flask.render_template('admin.html', emergencies=emergencies,
                                  **template_kwargs())
 
-@app.route('/admin/send-alert')
+@app.route('/admin/send-alert/<type>/<id>')
 @user_is_an_admin
-def get_send_alert():
-    return flask.render_template('send-alert.html', **template_kwargs())
+def get_send_alert(type, id):
+    with psycopg2.connect(os.environ['DATABASE_URL']) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as db:
+            if type == 'fire':
+                emergency = wildfires.get_one_fire(db, id)
+    return flask.render_template('send-alert.html', emergency=emergency,
+                                 **template_kwargs())
 
 @app.route('/admin/sent')
 @user_is_an_admin

--- a/CDTADPQ/web/templates/admin.html
+++ b/CDTADPQ/web/templates/admin.html
@@ -8,16 +8,15 @@
   
   <ol>
     {% for emergency in emergencies %}
-        <li>{{ emergency }}</li>
+        <li>
+            {{ emergency.title }}
+            <a href="{{ url_for('get_send_alert', type=emergency.type, id=emergency.id) }}">Tell people</a>
+        </li>
     {% endfor %}
   </ol>
   
   {% include 'includes/map.html' %}
 
   <p></p>
-  <div class="button_wrapper">
-    <a href="{{ url_for('get_send_alert') }}" class="usa-button">Setup and send an alert about an emergency</a>
-  </div>
-   
   
 {% endblock %}

--- a/CDTADPQ/web/templates/admin.html
+++ b/CDTADPQ/web/templates/admin.html
@@ -6,6 +6,12 @@
 {% block main_content %}
   <h1>Admin - Current emergencies</h1>
   
+  <ol>
+    {% for emergency in emergencies %}
+        <li>{{ emergency }}</li>
+    {% endfor %}
+  </ol>
+  
   {% include 'includes/map.html' %}
 
   <p></p>

--- a/CDTADPQ/web/templates/send-alert.html
+++ b/CDTADPQ/web/templates/send-alert.html
@@ -6,12 +6,12 @@
 {% block main_content %}
   <h1>Admin - Current emergencies</h1>
   
-  <form action="{{ url_for('get_sent_alert') }}" method="post">
+  <form action="{{ url_for('post_send_alert') }}" method="post">
   
   <fieldset>
   <legend>This is the message that will be sent to anyone who has registered to be notified about this type of event.</legend>
-  	<label for="input-type-textarea">SMS Message</label>
-  	<textarea id="input-type-textarea" name="input-type-textarea">There is an emergency near you:&#13;&#10;{{ emergency.description }}&#13;&#10;&#13;&#10;Learn more at [URL].</textarea>
+  	<label for="emergency-message">SMS Message</label>
+  	<textarea id="emergency-message" name="emergency-message">There is an emergency near you:&#13;&#10;{{ emergency.description }}&#13;&#10;&#13;&#10;Learn more at [URL].</textarea>
   	<p>Maximum 140 characters</p>
   </fieldset>
   

--- a/CDTADPQ/web/templates/send-alert.html
+++ b/CDTADPQ/web/templates/send-alert.html
@@ -11,7 +11,7 @@
   <fieldset>
   <legend>This is the message that will be sent to anyone who has registered to be notified about this type of event.</legend>
   	<label for="emergency-message">SMS Message</label>
-  	<textarea id="emergency-message" name="emergency-message">There is an emergency near you:&#13;&#10;{{ emergency.description }}&#13;&#10;&#13;&#10;Learn more at [URL].</textarea>
+  	<textarea id="emergency-message" name="emergency-message" maxlength="140">There is an emergency near you:&#13;&#10;{{ emergency.description }}&#13;&#10;&#13;&#10;Learn more at [URL].</textarea>
   	<p>Maximum 140 characters</p>
   </fieldset>
   

--- a/CDTADPQ/web/templates/send-alert.html
+++ b/CDTADPQ/web/templates/send-alert.html
@@ -6,17 +6,19 @@
 {% block main_content %}
   <h1>Admin - Current emergencies</h1>
   
+  <form action="{{ url_for('get_sent_alert') }}" method="post">
+  
   <fieldset>
   <legend>This is the message that will be sent to anyone who has registered to be notified about this type of event.</legend>
   	<label for="input-type-textarea">SMS Message</label>
-  	<textarea id="input-type-textarea" name="input-type-textarea">[pre-fill this with generated information about alert]</textarea>
+  	<textarea id="input-type-textarea" name="input-type-textarea">There is an emergency near you:&#13;&#10;{{ emergency.description }}&#13;&#10;&#13;&#10;Learn more at [URL].</textarea>
   	<p>Maximum 140 characters</p>
   </fieldset>
-
-  <div class="button_wrapper">
-    <!-- [ reinstate this button instead of anchor when form is working ] button>Send alert</button-->
-    <a href="{{ url_for('get_sent_alert') }}" class="usa-button">Send alert</a>
-  </div>
-   
+  
+  <input type="hidden" name="emergency-type" value="{{ emergency.type }}">
+  <input type="hidden" name="emergency-id" value="{{ emergency.id }}">
+  <button class="usa-button-secondary">Send Alerts</button>
+  
+  </form>
   
 {% endblock %}


### PR DESCRIPTION
Closes #41.

- [x] Admin user can log into an admin area
- [x] Current fires are shown in a list
- [x] Admin user can choose one to tell people about
- [x] Admin user can write a short message
- [x] Messages probably go out?
- [x] Show how many characters the message uses
- [x] Send to users within some reasonable distance of the event (https://github.com/VeryLittleGravitas/CDTADPQ/issues/74)