### PR TITLE
Ensure admin triggered fire notifications are logged

### DIFF
--- a/CDTADPQ/web/__init__.py
+++ b/CDTADPQ/web/__init__.py
@@ -255,6 +255,7 @@ def post_send_alert():
                 for user in notify.get_users_to_notify(db, emergency):
                     print('notify.send_notification:', user, emergency)
                     notify.send_notification(twilio_account, user, emergency)
+                    send_notification(twilio_account, user, emergency)
     return flask.redirect(flask.url_for('get_sent_alert'), code=303)
 
 @app.route('/admin/sent')


### PR DESCRIPTION
Related to https://github.com/VeryLittleGravitas/CDTADPQ/issues/41

This isn't for the freeform textarea, but for specific emergency (fire) notifications sent through the admin pages. 